### PR TITLE
BugFix: Fixing API call made for ICD10-CM ontologies in Comprehend Medical

### DIFF
--- a/source/lambda/helper/python/comprehendHelper.py
+++ b/source/lambda/helper/python/comprehendHelper.py
@@ -155,9 +155,8 @@ class ComprehendHelper:
 
             # service limit is 10tps, sdk implements 3 retries with backoff
             # if that's not enough then fail
-            # response = client.infer_icd10_cm(Text=rawPages[index])
-            response = client.detect_entities_v2(Text=rawPages[index])
-
+            response = client.infer_icd10_cm(Text=rawPages[index])
+            
             # save results for later processing
             if 'Entities' not in response:
                 return


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bug Fix:
For Comprehend Medical ICD10 CM, DUS was calling detect_entities_V2 API where the call had to be made to infer_icd10_cm API

Fixed the API call in this PR



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
