### PR TITLE
Index searchable documents (images and pdfs) in kendra

### DIFF
--- a/source/app/components/DocumentPreview/DocumentPreview.js
+++ b/source/app/components/DocumentPreview/DocumentPreview.js
@@ -51,7 +51,7 @@ export default function DocumentPreview({
             {track === 'search' ? (
                   <div className={css.downloadButtons}>
                   <Button
-                  download="searchable-pdf.pdf"
+                  download={document.documentName.split('.')[0]+"-searchable.pdf"}
                   href={document.searchablePdfURL}
                   >
                     ⬇ Searchable PDF

--- a/source/app/store/entities/documents/actions.js
+++ b/source/app/store/entities/documents/actions.js
@@ -146,7 +146,7 @@ export const fetchDocument = createAction(FETCH_DOCUMENT, async documentid => {
 
   // Remove the last slash and everything before it
   const documentName = objectName.replace(/^.*\//, "");
-
+  const fileNameWithoutExtension = documentName.split(".")[0]
   // Amplify prepends public/ to the path, so we have to strip it
   const documentPublicSubPath = objectName.replace("public/", "");
   const resultDirectory = `${documentId}/output`;
@@ -161,7 +161,7 @@ export const fetchDocument = createAction(FETCH_DOCUMENT, async documentid => {
       bucket: bucketName,
       download: true
     }),
-    Storage.get(`${resultDirectory}/searchable-pdf.pdf`, {
+    Storage.get(`${resultDirectory}/${fileNameWithoutExtension}-searchable.pdf`, {
       download: true
     })
   ]);

--- a/source/lambda/jobresultprocessor/lambda_function.py
+++ b/source/lambda/jobresultprocessor/lambda_function.py
@@ -25,7 +25,8 @@ from kendraHelper import KendraHelper
 def generatePdf(documentId, bucketName, objectName, responseBucketName,outputPath):
     
     responseDocumentName = "{}{}response.json".format(outputPath,TEXTRACT_PATH_S3_PREFIX)
-    outputDocumentName = "{}searchable-pdf.pdf".format(outputPath)
+    fileName = os.path.basename(objectName).split(".")[0]
+    outputDocumentName = "{}{}-searchable.pdf".format(outputPath, fileName)
 
     data = {}
     data["bucketName"] = bucketName
@@ -134,10 +135,12 @@ def processRequest(request):
     # if Kendra is available then let it index the document
     if 'KENDRA_INDEX_ID' in os.environ:
         kendraClient = KendraHelper()
+        fileName = os.path.basename(objectName).split(".")[0]
+        outputDocumentName = "{}{}-searchable.pdf".format(outputPath, fileName)
         kendraClient.indexDocument(os.environ['KENDRA_INDEX_ID'],
                                    os.environ['KENDRA_ROLE_ARN'],
                                    bucketName,
-                                   objectName,
+                                   outputDocumentName,
                                    documentId)
 
     print("DocumentId: {}".format(documentId))

--- a/source/lambda/syncprocessor/lambda_function.py
+++ b/source/lambda/syncprocessor/lambda_function.py
@@ -25,7 +25,8 @@ from kendraHelper import KendraHelper
 def generatePdf(documentId, bucketName, objectName, responseBucketName, outputPath):
 
     responseDocumentName = "{}{}response.json".format(outputPath,TEXTRACT_PATH_S3_PREFIX)
-    outputDocumentName = "{}searchable-pdf.pdf".format(outputPath)
+    fileName = os.path.basename(objectName).split(".")[0]
+    outputDocumentName = "{}{}-searchable.pdf".format(outputPath,fileName)
 
     data = {}
     data["bucketName"] = bucketName
@@ -108,12 +109,15 @@ def processImage(documentId, features, bucketName, outputBucketName, objectName,
     comprehendAndMedicalEntities = comprehendClient.processComprehend(outputBucketName, responseDocumentName, comprehendOutputPath, maxPages)
 
     # if Kendra is available then let it index the document
+    # index the searchable pdf in Kendra
     if 'KENDRA_INDEX_ID' in os.environ :
         kendraClient = KendraHelper()
+        fileName = os.path.basename(objectName).split(".")[0]
+        outputDocumentName = "{}{}-searchable.pdf".format(outputPath, fileName)
         kendraClient.indexDocument(os.environ['KENDRA_INDEX_ID'],
                                    os.environ['KENDRA_ROLE_ARN'],
                                    outputBucketName,
-                                   objectName,
+                                   outputDocumentName,
                                    documentId)
 
     print("DocumentId: {}".format(documentId))


### PR DESCRIPTION
*Issue #, if available:*
Kendra was not able to search through images at the moment since we were not indexing their searchable pdfs. 

*Description of changes:*
1. change the name of output document from searchable-pdf.pdf to filenameWithoutExtension-searchable.pdf
2. Indexed the searchable image and pdf files in kendra

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.