### PR TITLE
Bulk throttle

### DIFF
--- a/source/lambda/helper/python/comprehendHelper.py
+++ b/source/lambda/helper/python/comprehendHelper.py
@@ -25,8 +25,8 @@ MAX_COMPREHEND_UTF8_PAGE_SIZE = 5000
 # Comprehend batch API call has a limit of 25
 PAGES_PER_BATCH = 15
 
-# maximum retries of a comprehend and comprehend medical API call
-MAX_API_RETRIES = 5
+# maximum retries for comprehend and comprehend medical API call
+MAX_API_RETRIES = 4
 
 
 class ComprehendHelper:
@@ -100,11 +100,11 @@ class ComprehendHelper:
                                           comprehendEntities):
 
         retries = 0
+        client = boto3.client('comprehend')
         
-        while retries < MAX_API_RETRIES:
+        while retries <= MAX_API_RETRIES:
             try:
-                client = boto3.client('comprehend')
-
+               
                 textPages = []
                 endIndex = pageStartIndex + pagesToProcess
 
@@ -130,7 +130,7 @@ class ComprehendHelper:
                 print("batchComprehendDetectEntitiesSync Exception: %s" % str(e))
         
             retries += 1
-            time.sleep(retries * 2)
+            time.sleep(retries * retries)
 
         print("batchComprehendDetectEntitiesSync: unable to process, API max retries reached")
                 
@@ -144,11 +144,11 @@ class ComprehendHelper:
                                             comprehendMedicalEntities,
                                             mutex):
         retries = 0
+        client = boto3.client('comprehendmedical')
     
-        while retries < MAX_API_RETRIES:
+        while retries <= MAX_API_RETRIES:
             try:
-                client = boto3.client('comprehendmedical')
-
+               
                 # service limit is 10tps, sdk implements 3 retries with backoff
                 # if that's not enough then fail
                 response = client.detect_entities_v2(Text=rawPages[index])
@@ -170,7 +170,7 @@ class ComprehendHelper:
                 print("comprehendMedicalDetectEntitiesSync Exception: %s" % str(e))
 
             retries += 1
-            time.sleep(retries * 2)
+            time.sleep(retries * retries)
         
         print("comprehendMedicalDetectEntitiesSync: unable to process, API max retries reached")
         
@@ -185,14 +185,13 @@ class ComprehendHelper:
                                          mutex):
 
         retries = 0
+        client = boto3.client('comprehendmedical')
         
-        while retries < MAX_API_RETRIES:
+        while retries <= MAX_API_RETRIES:
             try:
-                client = boto3.client('comprehendmedical')
-
+                
                 # service limit is 10tps, sdk implements 3 retries with backoff
                 # if that's not enough then fail
-            
                 response = client.infer_icd10_cm(Text=rawPages[index])
                 
                 # save results for later processing
@@ -212,7 +211,7 @@ class ComprehendHelper:
                 print("comprehendMedicalDetectICD10Sync Exception: %s" % str(e))
 
             retries += 1
-            time.sleep(retries * 2)
+            time.sleep(retries * retries)
 
         print("comprehendMedicalDetectICD10Sync: unable to process, API max retries reached")
 

--- a/source/lambda/helper/python/comprehendHelper.py
+++ b/source/lambda/helper/python/comprehendHelper.py
@@ -125,9 +125,9 @@ class ComprehendHelper:
                 return
         
             except ClientError as e:
-                print("batchComprehendDetectEntitiesSync Exception ClientError: %s" % e)
+                print("batchComprehendDetectEntitiesSync Exception ClientError: %s" % str(e))
             except Exception as e:
-                print("batchComprehendDetectEntitiesSync Exception: %s" % e)
+                print("batchComprehendDetectEntitiesSync Exception: %s" % str(e))
         
             retries += 1
             time.sleep(retries * 2)
@@ -165,9 +165,9 @@ class ComprehendHelper:
                 return
             
             except ClientError as e:
-                print("comprehendMedicalDetectEntitiesSync ClientError: %s" % e)
+                print("comprehendMedicalDetectEntitiesSync ClientError: %s" % str(e))
             except Exception as e:
-                print("comprehendMedicalDetectEntitiesSync Exception: %s" % e)
+                print("comprehendMedicalDetectEntitiesSync Exception: %s" % str(e))
 
             retries += 1
             time.sleep(retries * 2)
@@ -207,9 +207,9 @@ class ComprehendHelper:
                 return
             
             except ClientError as e:
-                print("comprehendMedicalDetectICD10Sync ClientError: %s" % e)
+                print("comprehendMedicalDetectICD10Sync ClientError: %s" % str(e))
             except Exception as e:
-                print("comprehendMedicalDetectICD10Sync Exception: %s" % e)
+                print("comprehendMedicalDetectICD10Sync Exception: %s" % str(e))
 
             retries += 1
             time.sleep(retries * 2)

--- a/source/lib/cdk-textract-stack.ts
+++ b/source/lib/cdk-textract-stack.ts
@@ -418,7 +418,7 @@ export class CdkTextractStack extends cdk.Stack {
       this,
       this.resourceName("DocumentBulkProcessingQueue"),
       {
-        visibilityTimeout: cdk.Duration.seconds(300),
+        visibilityTimeout: cdk.Duration.seconds(600),
         retentionPeriod: cdk.Duration.seconds(1209600),
         encryption: QueueEncryption.KMS_MANAGED,
         encryptionMasterKey: bulkProcessingKey,
@@ -759,7 +759,7 @@ export class CdkTextractStack extends cdk.Stack {
         runtime: lambda.Runtime.PYTHON_3_8,
         code: lambda.Code.fromAsset("lambda/documentbulkprocessor"),
         handler: "lambda_function.lambda_handler",
-        reservedConcurrentExecutions: API_CONCURRENT_REQUESTS / 3,
+        reservedConcurrentExecutions: 1,
         timeout: cdk.Duration.seconds(300),
         tracing: lambda.Tracing.ACTIVE,
         environment: {


### PR DESCRIPTION
*Issue #, if available:*

a high failure rate in the bulk processing of PDF and PNG

*Description of changes:*

The bulk processor was feeding documents into DUS at a rate beyond its current capacity.  This was causing timeouts and also rate limit exceeded from services, especially ComprehendMedical which doesn't have currently a call "batching" feature.  At present, 2 calls per page need to be made to ComprehendMedical.  Rate limits are handled by retrying with an exponential backoff. 
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.