### PR TITLE
Add unit tests for helper and datastore classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Please ensure you install all requirements before beginning the deployment
 
   ```sudo yum -y install jq```
 
+- moto (Required for running the tests)
+``` pip install moto ```
+
 To deploy using this approach, you must first set few values inside the `package.json` file in the `source` folder.
 
 - Set your deployment region in the `stack->region` property, replacing `"%%REGION%%"`. This deployment will not pull the AWS region from your current AWS profile. 

--- a/source/bin/run-tests.sh
+++ b/source/bin/run-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "running tests for S3helper and DynamoDBHelper."
+python3 test/test_helper.py
+echo "Running tests for datastore"
+python3 test/test_datastore.py

--- a/source/package.json
+++ b/source/package.json
@@ -31,7 +31,7 @@
     "deploy:setup-user": "AWS_REGION=$npm_package_stack_region node bin/user-setup.js",
     "deploy:setup-samples": "AWS_REGION=$npm_package_stack_region ENABLE_KENDRA=$npm_package_enableKendra bash ./bin/upload-samples.sh",
     "deploy-all": "yarn compile-ts-stacks && yarn bootstrap && yarn deploy:backend && yarn deploy:client && yarn update-pdf-lambda-code && yarn deploy:setup-samples",
-    "deploy": "yarn deploy-all ",
+    "deploy": "yarn run:tests && yarn deploy-all ",
     "deploy:frontend": "yarn deploy:client && yarn deploy:setup-samples",
     "destroy": "STACKNAME=$npm_package_stack_stackname AWS_REGION=$npm_package_stack_region cdk destroy -v true -a \"node bin/deploy-client-stack.js\" && STACKNAME=$npm_package_stack_stackname AWS_REGION=$npm_package_stack_region USER_EMAIL=$npm_package_email cdk destroy -v true",
     "update-client-stack-variables": "bash ../deployment/custom-deployment/bin/stack-variables-to-client.sh",
@@ -44,7 +44,8 @@
     "prettier": "prettier --write '**/*.{js,md,yaml}'",
     "lint": "yarn lint:js && yarn lint:css",
     "lint:css": "sass-lint --verbose --no-exit",
-    "lint:js": "eslint './**/*.js' --max-warnings 0"
+    "lint:js": "eslint './**/*.js' --max-warnings 0",
+    "run:tests": "bash bin/run-tests.sh"
   },
   "dependencies": {
     "@aws-cdk/aws-apigateway": "^1.42.0",

--- a/source/test/test_datastore.py
+++ b/source/test/test_datastore.py
@@ -47,7 +47,7 @@ class TestDocumentStore(unittest.TestCase):
         response = self.ds.createDocument(documentId, bucketName, objectName)
         self.assertEqual(response, None)
     
-    def test_create_duplicate_documentid_throws_error(self):
+    def test_create_duplicate_document_id_throws_error(self):
         bucketName = "dusstack-sample-s3-bucket"
         objectName = "public/samples/Finance/report.pdf"
         documentId = "b1a54fda-1809-49d7-8f19-0d1688eb65b9"
@@ -59,7 +59,7 @@ class TestDocumentStore(unittest.TestCase):
         response = self.ds.updateDocumentStatus(documentId, "FAILED")
         self.assertEqual(response, None)
     
-    def test_update_document_status_throws_error_when_document_doesnot_exist(self):
+    def test_update_document_status_throws_error_when_document_does_not_exist(self):
         documentId = "b1333fda-1809-49d7-8f19-0d1688eb65b9"
         response = self.ds.updateDocumentStatus(documentId, "FAILED")
         self.assertEqual(response, {'Error': 'Document does not exist.'})
@@ -86,14 +86,31 @@ class TestDocumentStore(unittest.TestCase):
     def test_get_documents(self):
         response = self.ds.getDocuments()
         self.assertEqual(len(response['documents']),2)
+        document_ids = []
+        for document in response['documents']:
+            document_ids.append(document['documentId'])
+        self.assertTrue('b1a54fda-1809-49d7-8f19-0d1688eb65b9' in document_ids)
+        self.assertTrue('b1a99fda-1809-49d7-8f19-0d1688eb65b9' in document_ids)
+
     
     def test_get_document_count(self):
         response = self.ds.getDocumentCount()
         self.assertEqual(response, 2)
+    
+    def test_get_table(self):
+        response = self.ds.getTable()
+        self.assertEqual(response.name,DOCUMENTS_TABLE_NAME)
+        self.assertTrue("dynamodb.Table" in response.__class__.__name__)
+    
+    def test_get_document(self):
+        documentId = 'b1a99fda-1809-49d7-8f19-0d1688eb65b9'
+        response = self.ds.getDocument(documentId)
+        self.assertEqual(response['documentStatus'], 'IN_PROGRESS')
+        self.assertEqual(response['documentId'], documentId)
+        self.assertEqual(response['bucketName'], "dusstack-sample-s3-bucket")
 
     def tearDown(self):
         self.conn.delete_table(TableName=DOCUMENTS_TABLE_NAME)
-
 
 
 if __name__=='__main__':

--- a/source/test/test_datastore.py
+++ b/source/test/test_datastore.py
@@ -1,0 +1,100 @@
+import sys
+sys.path.append("./lambda/helper/python")
+import boto3
+import unittest
+from moto import mock_s3
+from moto import mock_dynamodb2
+import datastore
+
+DOCUMENTS_TABLE_NAME="DocumentsTestTable"
+OUTPUT_TABLE_NAME="OutputTestTable"
+REGION="us-west-2"
+
+@mock_dynamodb2
+class TestDocumentStore(unittest.TestCase):
+    def setUp(self):
+        self.conn = boto3.client('dynamodb',region_name=REGION)
+        self.conn.create_table(
+            TableName = DOCUMENTS_TABLE_NAME,
+            KeySchema = [{"AttributeName": "documentId","KeyType":"HASH"}],
+            AttributeDefinitions=[{"AttributeName": "documentId", "AttributeType": "S"}],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+        )
+        self.conn.put_item(
+            TableName = DOCUMENTS_TABLE_NAME,
+            Item={
+                "documentId": {"S" : "b1a54fda-1809-49d7-8f19-0d1688eb65b9"},
+                "objectName": {"S": "public/samples/Misc/expense.png"},
+                "bucketName": {"S": "dusstack-sample-s3-bucket"},
+                "documentStatus": {"S": "IN_PROGRESS"}
+            }
+        )
+        self.conn.put_item(
+            TableName = DOCUMENTS_TABLE_NAME,
+            Item={
+                "documentId": {"S" : "b1a99fda-1809-49d7-8f19-0d1688eb65b9"},
+                "objectName": {"S": "public/samples/Misc/expense.png"},
+                "bucketName": {"S": "dusstack-sample-s3-bucket"},
+                "documentStatus": {"S": "IN_PROGRESS"}
+            }
+        )
+        self.ds = datastore.DocumentStore(DOCUMENTS_TABLE_NAME,OUTPUT_TABLE_NAME)
+    
+    def test_create_document_success(self):
+        bucketName = "dusstack-sample-s3-bucket"
+        objectName = "public/samples/Finance/report.pdf"
+        documentId = "b1a66fda-1809-49d7-8f19-0d1688eb65b9"
+        response = self.ds.createDocument(documentId, bucketName, objectName)
+        self.assertEqual(response, None)
+    
+    def test_create_duplicate_documentid_throws_error(self):
+        bucketName = "dusstack-sample-s3-bucket"
+        objectName = "public/samples/Finance/report.pdf"
+        documentId = "b1a54fda-1809-49d7-8f19-0d1688eb65b9"
+        response = self.ds.createDocument(documentId, bucketName, objectName)
+        self.assertEqual(response, {'Error': 'Document already exist.'})
+    
+    def test_update_document_status_success(self):
+        documentId = "b1a54fda-1809-49d7-8f19-0d1688eb65b9"
+        response = self.ds.updateDocumentStatus(documentId, "FAILED")
+        self.assertEqual(response, None)
+    
+    def test_update_document_status_throws_error_when_document_doesnot_exist(self):
+        documentId = "b1333fda-1809-49d7-8f19-0d1688eb65b9"
+        response = self.ds.updateDocumentStatus(documentId, "FAILED")
+        self.assertEqual(response, {'Error': 'Document does not exist.'})
+    
+    def test_mark_document_complete_success(self):
+        documentId = "b1a54fda-1809-49d7-8f19-0d1688eb65b9"
+        response = self.ds.markDocumentComplete(documentId)
+        documentStatus = self.conn.get_item(
+            Key={'documentId': {'S': documentId}},
+            TableName=DOCUMENTS_TABLE_NAME
+        )['Item']['documentStatus']['S']
+        self.assertEqual(documentStatus, "SUCCEEDED")
+        self.assertEqual(response, None)
+    
+    def test_delete_document_success(self):
+        documentId = "b1a54fda-1809-49d7-8f19-0d1688eb65b9"
+        self.ds.deleteDocument(documentId)
+        response = self.conn.get_item(
+            Key={'documentId': {'S': documentId}},
+            TableName=DOCUMENTS_TABLE_NAME
+        )
+        self.assertTrue('Item' not in response)
+    
+    def test_get_documents(self):
+        response = self.ds.getDocuments()
+        self.assertEqual(len(response['documents']),2)
+    
+    def test_get_document_count(self):
+        response = self.ds.getDocumentCount()
+        self.assertEqual(response, 2)
+
+    def tearDown(self):
+        self.conn.delete_table(TableName=DOCUMENTS_TABLE_NAME)
+
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/source/test/test_helper.py
+++ b/source/test/test_helper.py
@@ -17,16 +17,16 @@ class TestS3Helper(unittest.TestCase):
         self.conn = boto3.resource('s3', region_name=REGION)
         self.conn.create_bucket(Bucket=BUCKET_NAME, CreateBucketConfiguration={'LocationConstraint': REGION})
 
-    def test_gets3BucketRegion(self):
+    def test_get_s3_bucket_region(self):
         bucketRegion = S3Helper.getS3BucketRegion(BUCKET_NAME)
         self.assertEqual(bucketRegion,REGION)
     
-    def test_writeToS3(self):
+    def test_write_to_s3(self):
         S3Helper.writeToS3("Hello World", BUCKET_NAME, S3_FILE_NAME, REGION)
         body = self.conn.Object(BUCKET_NAME, S3_FILE_NAME).get()['Body'].read().decode('utf-8')
         self.assertEqual(body, "Hello World")
     
-    def test_readFromS3(self):
+    def test_read_from_s3(self):
         self.conn.Object(BUCKET_NAME, S3_FILE_NAME).put(Body="Test")
         body = S3Helper.readFromS3(BUCKET_NAME, S3_FILE_NAME, REGION)
         self.assertEqual(body,"Test")
@@ -56,12 +56,12 @@ class TestDynamoDBHelper(unittest.TestCase):
             }
         )
 
-    def test_getItems(self):
+    def test_get_items(self):
         items = DynamoDBHelper.getItems(TABLE_NAME, "forum_name", "Test")
         expected_result = [{'forum_name': 'Test', 'subject': 'test subject'}]
         self.assertEqual(items, expected_result)
     
-    def test_insertItem(self):
+    def test_insert_item(self):
         new_item = {
                 "forum_name": "Test2",
                 "subject": "test subject2"

--- a/source/test/test_helper.py
+++ b/source/test/test_helper.py
@@ -1,0 +1,76 @@
+import sys
+sys.path.append("./lambda/helper/python")
+import boto3
+import unittest
+from moto import mock_s3
+from moto import mock_dynamodb2
+from helper import S3Helper
+from helper import DynamoDBHelper
+
+BUCKET_NAME = "test-bucket"
+S3_FILE_NAME = "test_file_name.txt"
+REGION = 'us-west-2'
+TABLE_NAME = "TestsTable"
+@mock_s3
+class TestS3Helper(unittest.TestCase):
+    def setUp(self):
+        self.conn = boto3.resource('s3', region_name=REGION)
+        self.conn.create_bucket(Bucket=BUCKET_NAME, CreateBucketConfiguration={'LocationConstraint': REGION})
+
+    def test_gets3BucketRegion(self):
+        bucketRegion = S3Helper.getS3BucketRegion(BUCKET_NAME)
+        self.assertEqual(bucketRegion,REGION)
+    
+    def test_writeToS3(self):
+        S3Helper.writeToS3("Hello World", BUCKET_NAME, S3_FILE_NAME, REGION)
+        body = self.conn.Object(BUCKET_NAME, S3_FILE_NAME).get()['Body'].read().decode('utf-8')
+        self.assertEqual(body, "Hello World")
+    
+    def test_readFromS3(self):
+        self.conn.Object(BUCKET_NAME, S3_FILE_NAME).put(Body="Test")
+        body = S3Helper.readFromS3(BUCKET_NAME, S3_FILE_NAME, REGION)
+        self.assertEqual(body,"Test")
+    
+    def tearDown(self):
+        buckets = boto3.client('s3').list_buckets()
+        for bucket in buckets['Buckets']:
+            s3_bucket = self.conn.Bucket(bucket['Name'])
+            s3_bucket.objects.all().delete()
+            s3_bucket.delete()
+
+@mock_dynamodb2
+class TestDynamoDBHelper(unittest.TestCase):
+    def setUp(self):
+        self.conn = boto3.client('dynamodb',region_name=REGION)
+        self.conn.create_table(
+            TableName = TABLE_NAME,
+            KeySchema = [{"AttributeName": "forum_name","KeyType":"HASH"}],
+            AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+        )
+        self.conn.put_item(
+            TableName = TABLE_NAME,
+            Item={
+                "forum_name": {"S" : "Test"},
+                "subject": {"S" : "test subject"}
+            }
+        )
+
+    def test_getItems(self):
+        items = DynamoDBHelper.getItems(TABLE_NAME, "forum_name", "Test")
+        expected_result = [{'forum_name': 'Test', 'subject': 'test subject'}]
+        self.assertEqual(items, expected_result)
+    
+    def test_insertItem(self):
+        new_item = {
+                "forum_name": "Test2",
+                "subject": "test subject2"
+            }
+        ddbResponse = DynamoDBHelper.insertItem(TABLE_NAME, new_item)
+        self.assertEqual(ddbResponse['ResponseMetadata']['HTTPStatusCode'],200)
+    
+    def tearDown(self):
+        self.conn.delete_table(TableName=TABLE_NAME)
+
+if __name__=='__main__':
+    unittest.main()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Adding tests for the s3helper, dynamodbhelper and Datastore classes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.