### PR TITLE
elasticsearch upgrade from 6.5 to 7.4

### DIFF
--- a/source/lambda/apiprocessor/search.py
+++ b/source/lambda/apiprocessor/search.py
@@ -40,8 +40,8 @@ def deleteESItem(elasticsearchDomain, documentId):
             connection_class=RequestsHttpConnection
         )
 
-        if es.exists(index="textract", doc_type="document", id=documentId):
-            es.delete(index="textract", doc_type="document", id=documentId)
+        if es.exists(index="textract", id=documentId):
+            es.delete(index="textract", id=documentId)
             print("Deleted document: {}".format(documentId))
 
 
@@ -118,7 +118,6 @@ def search(request):
 
         output = es.search(
             index='textract',
-            doc_type="document",
             body=searchBody,
             _source = True,
             filter_path=['hits.hits._id', 'hits.hits._source','hits.hits.highlight']

--- a/source/lambda/elasticsearch/requirements.txt
+++ b/source/lambda/elasticsearch/requirements.txt
@@ -1,7 +1,7 @@
 requests-aws4auth==0.9
-elasticsearch==5.5.3
+elasticsearch==7.9.1
 requests==2.21.0
 idna==2.8
 chardet==3.0.4
-certifi==2019.3.9
-urllib3==1.24.2
+certifi==2020.6.20
+urllib3==1.25.10

--- a/source/lambda/textractor/python/og.py
+++ b/source/lambda/textractor/python/og.py
@@ -201,20 +201,17 @@ class OutputGenerator:
                                     }
                                 },
                                 "mappings":{
-                                    "document":{
-                                        "properties":{
-                                        "date":{ 
-                                            "type": "date",
-                                            "format": "M'/'dd'/'yyyy||date||year||year_month||dd MMM yyyy||dd'/'MM'/'yyyy||yyyy'/'MM'/'dd||dd'/'MM'/'YY||year_month_day||MM'/'dd'/'yy||dd MMM||MM'/'yyyy||M-dd-yyyy||MM'/'dd'/'yyyy||M||d'/'MM'/'yyyy||MM'/'dd'/'yy"
-                                        }
+                                    "properties":{
+                                    "date":{
+                                        "type": "date",
+                                        "format": "M'/'dd'/'yyyy||date||year||year_month||dd MMM yyyy||dd'/'MM'/'yyyy||yyyy'/'MM'/'dd||dd'/'MM'/'YY||year_month_day||MM'/'dd'/'yy||dd MMM||MM'/'yyyy||M-dd-yyyy||MM'/'dd'/'yyyy||M||d'/'MM'/'yyyy||MM'/'dd'/'yy"
                                     }
                                 }
                             }
                         }
                     )
 
-                    es.index(index="textract", doc_type="document",
-                            id=self.documentId, body=json.loads(json.dumps(document)))
+                    es.index(index="textract", id=self.documentId, body=document)
 
                     print("Indexed document: {}".format(self.objectName))
                 except Exception as E:

--- a/source/lib/cdk-textract-stack.ts
+++ b/source/lib/cdk-textract-stack.ts
@@ -281,7 +281,7 @@ export class CdkTextractStack extends cdk.Stack {
         this,
         this.resourceName("ElasticSearchCluster"),
         {
-          elasticsearchVersion: "6.5",
+          elasticsearchVersion: "7.4",
           elasticsearchClusterConfig: {
             instanceType: "m5.large.elasticsearch",
           },
@@ -304,7 +304,7 @@ export class CdkTextractStack extends cdk.Stack {
         this,
         this.resourceName("ElasticSearchCluster"),
         {
-          elasticsearchVersion: "6.5",
+          elasticsearchVersion: "7.4",
           elasticsearchClusterConfig: {
             instanceType: "m5.large.elasticsearch",
             instanceCount: 2,


### PR DESCRIPTION
*Issue #, if available:*

elasticsearch version upgrade needed for security and approval.

*Description of changes:*

The new ES version and its python client have a different api specification.  Our use needed to be modified in order to create the index, index and delete documents, and search.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.