### PR TITLE
Switch to use IAM authorizationtype in API

### DIFF
--- a/source/app/store/entities/documents/actions.js
+++ b/source/app/store/entities/documents/actions.js
@@ -37,11 +37,6 @@ export const submitDocument = createAction(
   SUBMIT_DOCUMENT,
   async ({ sample, key }) => {
     const response = await API.post("TextractDemoTextractAPI", "document", {
-      headers: {
-        Authorization: `Bearer ${(await Auth.currentSession())
-          .getIdToken()
-          .getJwtToken()}`
-      },
       response: true,
       body: {
         sample: !!sample,
@@ -58,11 +53,6 @@ export const submitDocuments = createAction(
   SUBMIT_DOCUMENTS,
   async ({ objects }) => {
     const response = await API.post("TextractDemoTextractAPI", "document", {
-      headers: {
-        Authorization: `Bearer ${(await Auth.currentSession())
-          .getIdToken()
-          .getJwtToken()}`
-      },
       response: true,
       body: {
         objects
@@ -81,11 +71,6 @@ export const fetchDocuments = createAction(
   FETCH_DOCUMENTS,
   async ({ nextToken: nexttoken } = {}) => {
     const response = await API.get("TextractDemoTextractAPI", "documents", {
-      headers: {
-        Authorization: `Bearer ${(await Auth.currentSession())
-          .getIdToken()
-          .getJwtToken()}`
-      },
       response: true,
       queryStringParameters: reject(either(isNil, isEmpty), {
         nexttoken,
@@ -108,11 +93,6 @@ export const fetchSingleDocument = createAction(
   FETCH_DOCUMENT,
   async documentid => {
     const response = await API.get("TextractDemoTextractAPI", "document", {
-      headers: {
-        Authorization: `Bearer ${(await Auth.currentSession())
-          .getIdToken()
-          .getJwtToken()}`
-      },
       response: true,
       queryStringParameters: {
         documentid
@@ -130,11 +110,6 @@ export const fetchSingleDocument = createAction(
  */
 export const fetchDocument = createAction(FETCH_DOCUMENT, async documentid => {
   const response = await API.get("TextractDemoTextractAPI", "document", {
-    headers: {
-      Authorization: `Bearer ${(await Auth.currentSession())
-        .getIdToken()
-        .getJwtToken()}`
-    },
     response: true,
     queryStringParameters: {
       documentid
@@ -215,11 +190,6 @@ const comprehendRespone = JSON.parse(
 
 export const deleteDocument = createAction(FETCH_DOCUMENT, async documentid => {
   const response = await API.del("TextractDemoTextractAPI", "document", {
-    headers: {
-      Authorization: `Bearer ${(await Auth.currentSession())
-        .getIdToken()
-        .getJwtToken()}`
-    },
     response: true,
     queryStringParameters: {
       documentid

--- a/source/app/store/entities/searchResults/actions.js
+++ b/source/app/store/entities/searchResults/actions.js
@@ -24,21 +24,13 @@ import { searchResultsSchema, kendraResultsSchema,kendraFilteredResultsSchema } 
  * Get documents from TextractDemoTextractAPI
  */
 export const search = createAction(SEARCH, async params => {
-  const headers = {
-    Authorization: `Bearer ${(await Auth.currentSession())
-      .getIdToken()
-      .getJwtToken()}`
-  }
-
   const [ esResponse, kendraResponse, kendraFilteredResponse ] = await Promise.all([
     API.get("TextractDemoTextractAPI", "search", {
-      headers,
       response: true,
       queryStringParameters: { ...params }
     }),
 
     ENABLE_KENDRA ? API.post("TextractDemoTextractAPI", "searchkendra", {
-      headers,
       response: true,
       queryStringParameters: {},
       body: {
@@ -49,7 +41,6 @@ export const search = createAction(SEARCH, async params => {
     }) : null,
 
     ENABLE_KENDRA && params.persona ? API.post("TextractDemoTextractAPI", "searchkendra", {
-      headers,
       response: true,
       queryStringParameters: {},
       body: {
@@ -97,11 +88,6 @@ export const search = createAction(SEARCH, async params => {
 
 export const submitKendraFeedback = createAction(SUBMIT_FEEDBACK, async ({ relevance, queryId, resultId }) => {
   const response = await API.post("TextractDemoTextractAPI", "feedbackkendra", {
-    headers: {
-      Authorization: `Bearer ${(await Auth.currentSession())
-        .getIdToken()
-        .getJwtToken()}`
-    },
     response: true,
     body: {
       relevance,

--- a/source/lib/cdk-textract-stack.ts
+++ b/source/lib/cdk-textract-stack.ts
@@ -1238,14 +1238,6 @@ export class CdkTextractStack extends cdk.Stack {
       }
     );
 
-    const authorizer = new apigateway.CfnAuthorizer(this, "Authorizer", {
-      identitySource: "method.request.header.Authorization",
-      name: "Authorization",
-      type: "COGNITO_USER_POOLS",
-      providerArns: [textractUserPool.attrArn],
-      restApiId: api.restApiId,
-    });
-
     function addCorsOptionsAndMethods(
       apiResource: apigateway.IResource | apigateway.Resource,
       methods: string[] | []
@@ -1293,10 +1285,7 @@ export class CdkTextractStack extends cdk.Stack {
 
       methods.forEach((method) => {
         apiResource.addMethod(method, undefined, {
-          authorizationType: apigateway.AuthorizationType.COGNITO,
-          authorizer: {
-            authorizerId: `${authorizer.ref}`,
-          },
+          authorizationType: apigateway.AuthorizationType.IAM
         });
       });
     }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This switches the API Gateway authorizer from the existing Cognito authorizer to IAM - since all the necessary sigv4 request signing is handled internally by Amplify's API handler. This should open the possibility for adding an independent unauthorized role to the identity pool in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.