### PR TITLE
Changes to fix the error of blank page processing in DUS

### DIFF
--- a/source/lambda/helper/python/comprehendHelper.py
+++ b/source/lambda/helper/python/comprehendHelper.py
@@ -379,7 +379,9 @@ class ComprehendHelper:
             numOfPages = maxPages
 
         # iterate over results page by page and extract raw text for comprehend
-        rawPages = [""] * numOfPages
+        # initialize rawPages with atleast a 1 character string helps prevent errors produced by comprehend and comprehend medical
+        # comprehend and comprehend medical need text with atleast 1 character and infer_icd10_cm() needs a non empty string
+        rawPages = ["."] * numOfPages
         if self.extractTextByPages(textract, rawPages, numOfPages) == False:
             return False
 

--- a/source/lambda/textractor/python/og.py
+++ b/source/lambda/textractor/python/og.py
@@ -176,18 +176,19 @@ class OutputGenerator:
                 }
 
                 # add comprehend entities while indexing the document
-                for key, val in entitiesToIndex.items():
-                    key = key.lower()
-                    if(key == "date"):
-                        for date in val:
-                            date_object = format_date(date)
-                            if(date_object!= UNSUPPORTED_DATE_FORMAT):
-                                if(key not in document):
-                                    document[key] = []
-                                document[key].append(date_object.strftime("%Y-%m-%d"))
-                        print("Document updated with Converted dates")
-                    else:
-                        document[key] = val
+                if entitiesToIndex:
+                    for key, val in entitiesToIndex.items():
+                        key = key.lower()
+                        if(key == "date"):
+                            for date in val:
+                                date_object = format_date(date)
+                                if(date_object!= UNSUPPORTED_DATE_FORMAT):
+                                    if(key not in document):
+                                        document[key] = []
+                                    document[key].append(date_object.strftime("%Y-%m-%d"))
+                            print("Document with Converted dates: {}".format(document))
+                        else:
+                            document[key] = val
                     
                 try:
                     if not es_index_client.exists(index='textract'):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Added a check for entitiesToIndex, if it is empty, we do not process it to extract the items/keywords in it - will occur in case of a blank page
2. Comprehend/Comprehend Medical need atleast 1 character for the detect_entities and other API calls. We initialized rawPages with empty string without any chracters and this gave error for scenarios where the page does not have any text. Fixed this by initializing rawPages with a "." character so that comprehend does not error out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.