### PR TITLE
Add user Pool id to cloudformation stack output

### DIFF
--- a/source/lib/cdk-textract-stack.ts
+++ b/source/lib/cdk-textract-stack.ts
@@ -642,6 +642,8 @@ export class CdkTextractStack extends cdk.Stack {
       },
     });
 
+    new cdk.CfnOutput(this, 'DUSUserPoolId', { value: textractUserPool.ref });
+
     // Depends upon all other parts of the stack having been created.
     const textractUserPoolUser = new CfnUserPoolUser(
       this,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add user Pool id to cloudformation stack output to help collect cognito metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.