### PR TITLE
Pii entities, redacted item label optional and boto3 upgrade to 1.17

### DIFF
--- a/source/app/components/EntitiesCheckbox/EntitiesCheckbox.js
+++ b/source/app/components/EntitiesCheckbox/EntitiesCheckbox.js
@@ -25,6 +25,7 @@ import {
 
 import {
   COMPREHEND_MEDICAL_SERVICE,
+  COMPREHEND_PII,
   COMPREHEND_SERVICE
 } from '../../utils/dus-constants'
 
@@ -63,11 +64,14 @@ export default function EntitiesCheckbox({
   if (!entities.length&& visible) {
     return <p className={css.noEntity}>No {is_comprehend_medical? (`Medical `):null}Entities detected</p>
   }
+
+  const entityLabel = is_comprehend_medical ? 'Medical Entities' : comprehendService === COMPREHEND_PII ? 'PII Entities' : 'Entities';
+
   return (
 
     <div className={cs(css.entityList, visible && css.visible,)} ref={container}>
       <ul>
-        <h4>{is_comprehend_medical? (`Medical `):null}Entities: {entities.length || 0} Found</h4>
+        <h4>{entityLabel}: {entities.length || 0} Found</h4>
         {groupWith((a, b) => a.pageNumber === b.pageNumber)(entities).map((pairs, i) => (
           <Fragment key={pairs[0].pageNumber}>
             {pageCount > 1 ? (
@@ -128,7 +132,7 @@ export default function EntitiesCheckbox({
       <footer className={css.actions}>
       <div className={css.downloadButtons}>
       <Button  onClick={onDownloadPrimary}>
-      ⬇ {is_comprehend_medical? (`Medical `):null} Entities
+      ⬇ {entityLabel}
       </Button></div>
       {is_comprehend_medical?
       ( <div className={css.downloadButtons}><Button className={css.downloadButton} onClick={onDownloadSecondary}>

--- a/source/app/store/entities/documents/actions.js
+++ b/source/app/store/entities/documents/actions.js
@@ -160,6 +160,7 @@ export const fetchDocument = createAction(FETCH_DOCUMENT, async documentid => {
   const resultDirectory = `${documentId}/output`;
   const textractResponsePath = `${resultDirectory}/textract/response.json`;
   const comprehendMedicalResponsePath = `${resultDirectory}/comprehend/comprehendMedicalEntities.json` 
+  const comprehendPIIResponsePath = `${resultDirectory}/comprehend/comprehendPIIEntities.json` 
   const comprehendResponsePath = `${resultDirectory}/comprehend/comprehendEntities.json` 
   
   
@@ -204,6 +205,13 @@ export const fetchDocument = createAction(FETCH_DOCUMENT, async documentid => {
     const s3ComprehendMedicalResponseText = await s3ComprehendMedicalResponse.Body?.text()
     comprehendMedicalRespone = JSON.parse(s3ComprehendMedicalResponseText);
   }
+
+  const s3ComprehendPIIResponse = await Storage.get(comprehendPIIResponsePath, {
+    download: true
+  });
+  const s3ComprehendPIIResponseText = await s3ComprehendPIIResponse.Body?.text()
+  const comprehendPIIResponse = JSON.parse(s3ComprehendPIIResponseText);
+
   // Get the raw comprehend response data from a json file on S3
   const s3ComprehendResponse = await Storage.get(comprehendResponsePath, {
     download: true
@@ -222,6 +230,7 @@ export const fetchDocument = createAction(FETCH_DOCUMENT, async documentid => {
       textractResponse,
       textractFetchedAt: Date.now(),
       comprehendMedicalRespone,
+      comprehendPIIResponse,
       comprehendRespone,
       resultDirectory,
       redactions,

--- a/source/app/utils/document.js
+++ b/source/app/utils/document.js
@@ -35,7 +35,8 @@ import {
 
 import {
   COMPREHEND_MEDICAL_SERVICE,
-  COMPREHEND_SERVICE
+  COMPREHEND_SERVICE,
+  COMPREHEND_PII
 } from './dus-constants'
 
 import {getEscapedStringRegExp} from './getEscapedStringRegExp'
@@ -310,9 +311,11 @@ export function getPageEntityPairs(document, pageNumber,comprehendService) {
   // Get all blocks of Entities for a PAGE
   let blocks = []
   if (comprehendService == COMPREHEND_MEDICAL_SERVICE){
-   blocks = document.comprehendMedicalRespone["results"]
-  }else{
-   blocks = document.comprehendRespone["results"]  
+    blocks = document.comprehendMedicalRespone.results
+  } else if (comprehendService === COMPREHEND_PII) {
+    blocks = document.comprehendPIIResponse.results
+  } else{
+    blocks = document.comprehendRespone.results
   }
   const pageBlocks= blocks.filter(
     ({ Entities, Page }) =>

--- a/source/app/utils/dus-constants.js
+++ b/source/app/utils/dus-constants.js
@@ -13,4 +13,5 @@
  *********************************************************************************************************************/
 
 export const COMPREHEND_SERVICE = 'COMPREHEND'
+export const COMPREHEND_PII = 'COMPREHEND_PII'
 export const COMPREHEND_MEDICAL_SERVICE = 'COMPREHEND_MEDICAL'

--- a/source/app/utils/redaction.js
+++ b/source/app/utils/redaction.js
@@ -4,9 +4,11 @@ export const normalizeRedactionResponse = (redactions) => {
   const normalizedRedactions = {};
 
   redactions.forEach((redaction) => {
-    if (!normalizedRedactions[redaction.page]) normalizedRedactions[redaction.page] = {};
+    const page = redaction.page.toString()
 
-    normalizedRedactions[redaction.page][uuid()] = {
+    if (!normalizedRedactions[page]) normalizedRedactions[page] = {};
+
+    normalizedRedactions[page][uuid()] = {
       Top: redaction.top,
       Left: redaction.left,
       Width: redaction.width,
@@ -20,7 +22,7 @@ export const normalizeRedactionResponse = (redactions) => {
 export const getRedactionsDto = (redactions) =>
   Object.entries(redactions).flatMap(([page, redactionsOnPage]) =>
     Object.values(redactionsOnPage).map(({ Top: top, Left: left, Width: width, Height: height }) => ({
-      page,
+      page: Number(page),
       top,
       left,
       width,

--- a/source/lambda/apiprocessor/redaction.py
+++ b/source/lambda/apiprocessor/redaction.py
@@ -18,7 +18,6 @@ import json
 import os
 import re
 from helper import S3Helper, DynamoDBHelper
-import pdb
 
 # the maximum number of exclusion lists we support, like legal, marketing, etc
 MAXIMUM_EXCLUSION_LISTS = 100
@@ -276,8 +275,6 @@ def getRedactionGlobal(bucket):
     #
     # fetch redaction labels
     #
-    import pdb
-    pdb.set_trace()
     try:
         data = S3Helper.readFromS3(bucket, 'redactionglobal/labels.csv')
         lines = data.splitlines()

--- a/source/lambda/apiprocessor/redaction.py
+++ b/source/lambda/apiprocessor/redaction.py
@@ -32,7 +32,7 @@ HEADER_FOOTER_ITEM_KEYS = 4
 MAXIMUM_NUM_OF_HEADERS_FOOTERS = 3
 
 # we expect a redacted item to have 6 keys: page, top, left, width, height label
-REDACTED_ITEM_KEYS = 6
+REDACTED_ITEM_NUM_KEYS = 5
 
 # get the redacted items of this document
 def getDocumentRedaction(documentId, bucket):
@@ -130,10 +130,23 @@ def validateHeadersFooters(items, typeStr):
                     
                     
 def validateRedactedItem(item):
-                    
-    if len(item.keys()) != REDACTED_ITEM_KEYS:
+    
+    numOfkeys = len(item.keys())
+    
+    # the default number of mandatory keys
+    if numOfkeys == REDACTED_ITEM_NUM_KEYS:
+        pass
+    # case of the optional label key added, validate it here
+    elif numOfkeys == (REDACTED_ITEM_NUM_KEYS + 1):
+        
+        if 'label' not in item:
+            return (400, "bad request, redacted item optional key is not a redaction label")
+        
+        if isinstance(item['label'], str) == False:
+            return (400, "bad request, redacted item label is not a string")
+    else:
         return (400, "bad request, redacted item has invalid number of keys")
-            
+
     # validate page number
     if 'page' not in item:
         return (400, "bad request, redacted item has no page number")
@@ -183,13 +196,6 @@ def validateRedactedItem(item):
 
     if item['height'] < 0.0:
         return (400, "bad request, redacted item height number is invalid")
-
-   # validate label string
-    if 'label' not in item:
-        return (400, "bad request, redacted item has no label")
-
-    if isinstance(item['label'], str) == False:
-        return (400, "bad request, redacted item label is not a string")
 
     return (200, "ok")
 

--- a/source/lambda/apiprocessor/redaction.py
+++ b/source/lambda/apiprocessor/redaction.py
@@ -31,8 +31,11 @@ HEADER_FOOTER_ITEM_KEYS = 4
 # there can be 0 up to 3 headers maximum, same for footers
 MAXIMUM_NUM_OF_HEADERS_FOOTERS = 3
 
-# we expect a redacted item to have 6 keys: page, top, left, width, height label
-REDACTED_ITEM_NUM_KEYS = 5
+# we expect a redacted item to have 5 mandatory keys: page, top, left, width, height
+REDACTED_ITEM_NUM_MANDATORY_KEYS = 5
+
+# a redacted item may have an optional "label" key, for a total of 6 keys
+REDACTED_ITEM_NUM_MANDATORY_AND_OPTIONAL_KEYS = 6
 
 # get the redacted items of this document
 def getDocumentRedaction(documentId, bucket):
@@ -134,10 +137,10 @@ def validateRedactedItem(item):
     numOfkeys = len(item.keys())
     
     # the default number of mandatory keys
-    if numOfkeys == REDACTED_ITEM_NUM_KEYS:
+    if numOfkeys == REDACTED_ITEM_NUM_MANDATORY_KEYS:
         pass
     # case of the optional label key added, validate it here
-    elif numOfkeys == (REDACTED_ITEM_NUM_KEYS + 1):
+    elif numOfkeys == (REDACTED_ITEM_NUM_MANDATORY_AND_OPTIONAL_KEYS):
         
         if 'label' not in item:
             return (400, "bad request, redacted item optional key is not a redaction label")

--- a/source/lambda/boto3/requirements.txt
+++ b/source/lambda/boto3/requirements.txt
@@ -1,9 +1,9 @@
-docutils==0.15.2 
+docutils==0.16.0
 jmespath==0.10.0
 python_dateutil==2.8.1
-boto3==1.13.20 
-botocore==1.16.20
-s3transfer==0.3.3
+boto3==1.17.0
+botocore==1.20.0
+s3transfer==0.3.4
 six==1.15.0
-urllib3==1.25.9
+urllib3==1.26.3
 filetype==1.0.7

--- a/source/lambda/helper/python/comprehendHelper.py
+++ b/source/lambda/helper/python/comprehendHelper.py
@@ -313,9 +313,7 @@ class ComprehendHelper:
 
                     if e['Type'] not in pii_entities_to_index:
                         pii_entities_to_index[e['Type']] = []
-                    
-                    #pii_entities_to_index[ e['Type']].append(e['Text'])
-                    pii_entities_to_index[e['Type']].append("PII")
+                    pii_entities_to_index[e['Type']].append(e['Text'])
         
                     # make a note of this added entity
                     entities.add(e['Text'].upper())

--- a/source/lambda/helper/python/comprehendHelper.py
+++ b/source/lambda/helper/python/comprehendHelper.py
@@ -126,11 +126,44 @@ class ComprehendHelper:
         for i in range(0, pagesToProcess):
             comprehendEntities[pageStartIndex +
                                i] = response['ResultList'][i]
+
+    #
+    # thread execution calling Comprehend PII synchronously for each page
+    #
+
+    def comprehendDetectPIISync(self,
+                                rawPages,
+                                index,
+                                comprehendPIIEntities,
+                                mutex):
+        config = Config(
+                        retries = {
+                        'max_attempts': MAX_API_RETRIES,
+                        'mode': 'standard'
+                        }
+        )
+        
+        client = boto3.client('comprehend', config=config)
     
+        # service limit is 10tps, sdk implements 3 retries with backoff
+        # if that's not enough then fail
+        response = client.detect_pii_entities(Text=rawPages[index],
+                                              LanguageCode='en')
+
+        # save results for later processing
+        if 'Entities' not in response:
+            return
+
+        mutex.acquire()
+        comprehendPIIEntities[index] = response['Entities']
+        mutex.release()
+
+
+
     #
     # thread execution calling ComprehendMedical Entities synchronously for each page
     #
-    
+
     def comprehendMedicalDetectEntitiesSync(self,
                                             rawPages,
                                             index,
@@ -237,6 +270,61 @@ class ComprehendHelper:
         S3Helper.writeToS3(json.dumps(data), bucket,
                            comprehendOutputPath + "comprehendEntities.json")
         return entities_to_index
+
+    #
+    # processes all ComprehendMedical results for all pages
+    #
+    def processAndReturnComprehendPIIEntities(self,
+                                         comprehendPIIEntities,
+                                         rawPages,
+                                         numOfPages,
+                                         bucket,
+                                         comprehendOutputPath):
+
+        data = {}
+        data['results'] = []
+        pii_entities_to_index = {}
+        
+        for p in range(0, numOfPages):
+            
+            page = {}
+            # page numbers start at 1
+            page['Page'] = p + 1
+            page['Entities'] = []
+
+            # to detect and skip duplicates
+            entities = set()
+
+            for e in comprehendPIIEntities[p]:
+                
+                # comprehend doesn't return the text of the entity it detected, we must
+                # get it from the page we sent it originally
+                e['Text'] = rawPages[p][e['BeginOffset']:e['EndOffset']]
+                
+                # add this entity if not already present
+                if e['Text'].upper() not in entities:
+                    
+                    # add entity to results list
+                    entity = {}
+                    entity['Text'] = e['Text']
+                    entity['Type'] = e['Type']
+                    entity['Score'] = e['Score']
+                    page['Entities'].append(entity)
+
+                    if e['Type'] not in pii_entities_to_index:
+                        pii_entities_to_index[e['Type']] = []
+                    
+                    #pii_entities_to_index[ e['Type']].append(e['Text'])
+                    pii_entities_to_index[e['Type']].append("PII")
+        
+                    # make a note of this added entity
+                    entities.add(e['Text'].upper())
+
+            data['results'].append(page)
+                
+        # create results file in S3 under document folder
+        S3Helper.writeToS3(json.dumps(data), bucket, comprehendOutputPath + "comprehendPIIEntities.json")
+        return pii_entities_to_index
 
     #
     # processes all ComprehendMedical results for all pages
@@ -364,7 +452,6 @@ class ComprehendHelper:
                           isComprehendMedicalEnabled,
                           maxPages=200):
 
-
         # get textract results from S3
         textractFile = S3Helper.readFromS3(
             bucket, textractResponseLocation)
@@ -394,6 +481,7 @@ class ComprehendHelper:
             numOfBatches += 1
 
         # to store comprehend and medical API calls results.
+        comprehendPIIEntities = [None] * numOfPages
         comprehendEntities = [None] * numOfPages
         comprehendMedicalEntities = [None] * numOfPages
         comprehendMedicalICD10 = [None] * numOfPages
@@ -450,7 +538,22 @@ class ComprehendHelper:
                                             medicalICD10Mutex))
                     x.start()
                     threads.append(x)
+            
+                # comprehendPII is shared among threads
+                PIIMutex = threading.Lock()
 
+                for index in range(0, pagesToProcess):
+
+                    # Comprehend PII can only handle one page at a time synchronously. The SDK handles
+                    # throttling by the service.
+                    x = threading.Thread(target=self.comprehendDetectPIISync,
+                                        args=(rawPages,
+                                            pageStartIndex + index,
+                                            comprehendPIIEntities,
+                                            PIIMutex))
+                    x.start()
+                    threads.append(x)
+        
             # wait on all threads to finish their work
             for index, thread in enumerate(threads):
                 thread.join()
@@ -478,6 +581,13 @@ class ComprehendHelper:
                                        bucket,
                                        comprehendOutputPath)
 
+        # process comprehend PII data, create the entities result file in S3
+        comprehendPIIEntities = self.processAndReturnComprehendPIIEntities(comprehendPIIEntities,
+                                                                                   rawPages,
+                                                                                   numOfPages,
+                                                                                   bucket,
+                                                                                   comprehendOutputPath)
+                                       
         if(isComprehendMedicalEnabled):
             # process comprehend medical data, create the entities result file in S3
             comprehendMedicalEntities = self.processAndReturnComprehendMedicalEntities(comprehendMedicalEntities,

--- a/source/lib/cdk-textract-stack.ts
+++ b/source/lib/cdk-textract-stack.ts
@@ -1118,6 +1118,7 @@ export class CdkTextractStack extends cdk.Stack {
           actions: [
             "comprehend:BatchDetectEntities",
             "comprehend:DetectEntities",
+            "comprehend:DetectPiiEntities"
           ],
           resources: ["*"], // Currently, Comprehend does not support resource level permissionshttps://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazontextract.html#amazontextract-resources-for-iam-policies
         }),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Implementation of the new Comprehend Pii entities features.  A new tab is offered on the DUS console to see the pii entities and optionally redact them.  Changes are included for the general redaction feature to make the redaction "label" key in a redacted item optional.   An upgrade to boto3 1.17 was necessary in order to have access to the newer PII Comprehend api.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.